### PR TITLE
增加缺失的注解@Configuration

### DIFF
--- a/multi-tenant-server/src/main/java/com/ruoyi/framework/config/SecurityConfig.java
+++ b/multi-tenant-server/src/main/java/com/ruoyi/framework/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import com.ruoyi.framework.security.filter.JwtAuthenticationTokenFilter;
 import com.ruoyi.framework.security.handle.AuthenticationEntryPointImpl;
 import com.ruoyi.framework.security.handle.LogoutSuccessHandlerImpl;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * spring security配置
@@ -22,6 +23,7 @@ import com.ruoyi.framework.security.handle.LogoutSuccessHandlerImpl;
  * @author ruoyi
  */
 @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
+@Configuration
 public class SecurityConfig extends WebSecurityConfigurerAdapter
 {
     /**


### PR DESCRIPTION
该类属于配置类，需要加入@org.springframework.context.annotation.Configuration注解进行配置管理，利用Spring框架的IOC功能，将该类交给容器进行管理。